### PR TITLE
#15 ページ追加時のエラーを修正

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -127,7 +127,7 @@ export async function addReadingLog(
     userName,
     pages: currentTotalPages,
     comment: comment,
-    likedNum: likedNum,
+    likedNum: likedNum === undefined ? 0 : likedNum,
     createdAt: serverTimestamp(),
   });
 


### PR DESCRIPTION
fix #15 

`likedNum`が`undefined`の場合（既存ユーザーはすべてこうなっている）、ページ追加のタイミングで値を0に設定。